### PR TITLE
Fix missing require in ESM context

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "default": "./dist/index.js"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     },
     "./internals": {
       "development": "./src/internals.ts",
-      "default": "./dist/internals.js"
+      "import": "./dist/internals.js"
     },
     "./package.json": "./package.json"
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,14 +4,14 @@ export default defineConfig([
   // ESM build with types
   {
     entry: ["./src/index.ts"],
-    platform: "neutral",
+    platform: "node",
     dts: true,
     format: "esm",
   },
   // ESM build for internals with types
   {
     entry: ["./src/internals.ts"],
-    platform: "neutral",
+    platform: "node",
     dts: true,
     format: "esm",
   },


### PR DESCRIPTION
Fixes #6 

`tsdown` already has this configured, as long as we use the `node` platform in the configuration. See https://tsdown.dev/options/shims#the-require-function-in-esm.

Additionally, I fixed the `exports` field in the `package.json`. Consumers who use `require` or target `cjs` will get the CJS version, while `import` and `esm` targets will get the ESM version.