### PR TITLE
Drop vscode-extension-manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "bumpp": "^10.1.0",
     "eslint": "^9.32.0",
     "tsdown": "^0.11.9",
-    "typescript": "^5.8.3",
-    "vscode-extension-manifest": "^0.4.0"
+    "typescript": "^5.8.3"
   },
   "peerDependencies": {
     "@types/vscode": "^1.102.0",

--- a/src/language-registration-collection-builder.ts
+++ b/src/language-registration-collection-builder.ts
@@ -1,7 +1,7 @@
 import type { LanguageRegistration } from "shiki";
 import type { IRawGrammar } from "shiki/textmate";
 import type { LanguageConfiguration } from "vscode";
-import type { ExtensionGrammer as ExtensionGrammar, ExtensionLanguage } from "vscode-extension-manifest";
+import type { ExtensionGrammar, ExtensionLanguage } from "./manifest.js";
 
 import type { LanguageRegistry } from "./language-registry.js";
 import type { ExtensionFileReader } from "./vscode-utils.js";

--- a/src/language-registration-types.ts
+++ b/src/language-registration-types.ts
@@ -1,5 +1,5 @@
 import type { LanguageConfiguration } from "vscode";
-import type { ExtensionLanguage } from "vscode-extension-manifest";
+import type { ExtensionLanguage } from "./manifest.js";
 import type { LanguageRegistration } from "shiki";
 
 /**

--- a/src/language-registry.ts
+++ b/src/language-registry.ts
@@ -1,4 +1,4 @@
-import type { ExtensionGrammer as ExtensionGrammar, ExtensionLanguage, ExtensionManifest } from "vscode-extension-manifest";
+import type { ExtensionGrammar, ExtensionLanguage, ExtensionManifest } from "./manifest.js";
 import type { Extension, Uri } from "vscode";
 import { logger } from "./logger.js";
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,0 +1,79 @@
+
+export type ExtensionLanguage = {
+  aliases?: string[];
+  configuration?: string;
+  extensions?: string[];
+  filenamePatterns?: string[];
+  filenames?: string[];
+  firstLine?: string;
+  id?: string;
+  mimetypes?: string[];
+  icon?: {
+    dark: string;
+    light: string;
+  };
+};
+
+export type ExtensionGrammar = {
+  path: string;
+  scopeName: string;
+  balancedBracketScopes?: string[];
+  injectTo?: string[];
+  language?: string;
+  unbalancedBracketScopes?: string[];
+  embeddedLanguages?: {
+    [key: string]: string;
+  };
+  tokenTypes?: {
+    [key: string]: 'comment' | 'other' | 'string';
+  };
+};
+
+export type ExtensionTheme = {
+  path: string;
+  uiTheme: 'hc-black' | 'hc-light' | 'vs-dark' | 'vs';
+  id?: string;
+  label?: string;
+};
+
+export type ExtensionContributes = {
+  /**
+   * Contribute a TextMate grammar to a language. You must provide the language this grammar applies to, the TextMate scopeName for the grammar and the file path.
+   *
+   * @see {@link https://code.visualstudio.com/api/references/contribution-points#contributes.grammars}
+   */
+  grammars: ExtensionGrammar[];
+
+  /**
+   * Contribute definition of a programming language. This will introduce a new language or enrich the knowledge VS Code has about a language.
+   *
+   * The main effects of contributes.languages are:
+   *
+   * - Define a languageId that can be reused in other parts of VS Code API, such as vscode.TextDocument.languageId and the onLanguage Activation Events.
+   *    - You can contribute a human-readable using the aliases field. The first item in the list will be used as the human-readable label.
+   * - Associate file name extensions (extensions), file names (filenames), file name [glob patterns](https://code.visualstudio.com/docs/editor/glob-patterns) (filenamePatterns), files that begin with a specific line (such as hashbang) (firstLine), and mimetypes to that languageId.
+   * - Contribute a set of Declarative Language Features for the contributed language. Learn more about the configurable editing features in the Language Configuration Guide.
+   * - Contribute an icon which can be used as in file icon themes if theme does not contain an icon for the language
+   *
+   * @see {@link https://code.visualstudio.com/api/references/contribution-points#contributes.languages}
+   */
+  languages?: ExtensionLanguage[];
+  /**
+   * Contribute a color theme to VS Code, defining workbench colors and styles for syntax tokens in the editor.
+   *
+   * You must specify a label, whether the theme is a dark theme or a light theme (such that the rest of VS Code changes to match your theme) and the path to the file (JSON format).
+   *
+   * @see {@link https://code.visualstudio.com/api/references/contribution-points#contributes.themes}
+   */
+  themes?: ExtensionTheme[];
+}
+
+/**
+ * Extension Manifest
+ *
+ * @see {@link https://code.visualstudio.com/api/references/extension-manifest}
+ */
+export type ExtensionManifest = {
+  name: string;
+  contributes?: ExtensionContributes;
+};

--- a/src/theme-registration-builder.ts
+++ b/src/theme-registration-builder.ts
@@ -1,5 +1,5 @@
 import type { ThemeRegistration, ThemeRegistrationRaw, RawTheme } from "shiki";
-import type { ExtensionTheme } from "vscode-extension-manifest";
+import type { ExtensionTheme } from "./manifest.js";
 import type { ThemeRegistry } from "./theme-registry.js";
 import { type ExtensionFileReader } from "./vscode-utils.js";
 import { logger } from "./logger.js";

--- a/src/theme-registry.ts
+++ b/src/theme-registry.ts
@@ -1,5 +1,5 @@
 import type { Extension, Uri } from "vscode";
-import type { ExtensionManifest, ExtensionTheme } from "vscode-extension-manifest";
+import type { ExtensionManifest, ExtensionTheme } from "./manifest.js";
 import { logger } from "./logger.js";
 
 /**


### PR DESCRIPTION
The dependency `vscode-extension-manifest` is not used besides some partial types. Dropping this and defining the types as part of the source code removes the need for consumers to install `vscode-extension-manifest` themselves to get proper typing when using `vscode-shiki-bridge`.