### PR TITLE
Revert "Fix missing require in ESM context"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,20 +19,19 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "development": "./src/index.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./internals": {
       "types": "./dist/internals.d.ts",
       "development": "./src/internals.ts",
-      "import": "./dist/internals.js"
+      "default": "./dist/internals.js"
     },
     "./package.json": "./package.json"
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,14 +4,14 @@ export default defineConfig([
   // ESM build with types
   {
     entry: ["./src/index.ts"],
-    platform: "node",
+    platform: "neutral",
     dts: true,
     format: "esm",
   },
   // ESM build for internals with types
   {
     entry: ["./src/internals.ts"],
-    platform: "node",
+    platform: "neutral",
     dts: true,
     format: "esm",
   },


### PR DESCRIPTION
Reverts yoavbls/vscode-shiki-bridge#7

@kevinramharak I'm reverting it for now because I'm failing to build `pretty-ts-errors` on the `node` platform. I think it used cjs because it's vscode extension and it also missed the types because they're not exported directly